### PR TITLE
Also work with fields casted to array

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -52,7 +52,10 @@ export default {
   methods: {
     setInitialValue() {
       if (this.field.value) {
-        const valuesArray = JSON.parse(this.field.value);
+        const valuesArray = Array.isArray(this.field.value)
+          ? this.field.value
+          : JSON.parse(this.field.value);
+          
         if (!Array.isArray(valuesArray)) return (this.value = []);
 
         this.value = valuesArray


### PR DESCRIPTION
Currently, if the field is casted to an array in the model, the multiselect form does not work anymore. 

This patch attempts to fix this.