### PR TITLE
Bump Nova dependency to 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1.0",
-    "laravel/nova": "^2.0.11"
+    "laravel/nova": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
### This PR

Just bumps a Nova package dependency to 3.0, to make it compatible with both Laravel 7 \ Nova 3.
Not sure if I got the PR created right - didn't find any instructions for making contributions.