### PR TITLE
Fix bug causing nullable multiselects to save as 'null' string

### DIFF
--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -67,7 +67,7 @@ class Multiselect extends Field
         if ($singleSelect) {
             $model->{$attribute} = $value;
         } else {
-            $model->{$attribute} = $this->saveAsJSON ? $value : json_encode($value);
+            $model->{$attribute} = $this->saveAsJSON || is_null($value) ? $value : json_encode($value);
         }
     }
 


### PR DESCRIPTION
For nullable fields which do not saveAsJSON, if the value is null it was
being encoded and turned into a 'null' string. To resolve the issue,
add a check for if the value is null.