### PR TITLE
Set the options from the associated resources to use title method

### DIFF
--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -343,4 +343,18 @@ class Multiselect extends Field
     {
         return $this->withMeta(['clearOnSelect' => $clearOnSelect]);
     }
+
+    /**
+     * Set the options from a collection of models.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function setOptionsFromModels(Collection $models)
+    {
+        $options = $models->mapInto($this->resourceClass)->mapWithKeys(function ($associatedResource) {
+            return [$associatedResource->getKey() => $associatedResource->title()];
+        });
+        $this->options($options);
+    }
 }

--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -72,13 +72,10 @@ class Multiselect extends Field
             }
 
             try {
-                $options = [];
                 $modelObj = (new $this->resourceClass::$model);
                 $models = $this->resourceClass::$model::whereIn($modelObj->getKeyName(), $value)->get();
-                $models->each(function ($model) use (&$options) {
-                    $options[$model[$model->getKeyName()]] = (new $this->resourceClass($model))->title();
-                });
-                $this->options($options);
+
+                $this->setOptionsFromModels($models);
             } catch (Exception $e) {
             }
 
@@ -259,10 +256,7 @@ class Multiselect extends Field
 
             $models = $async ? $value : $resourceClass::$model::all();
 
-            $options = $models->mapInto($this->resourceClass)->mapWithKeys(function ($associatedResource) {
-                return [$associatedResource->getKey() => $associatedResource->title()];
-            });
-            $this->options($options);
+            $this->setOptionsFromModels($models);
 
             return $value->map(function ($model) {
                 return $model[$model->getKeyName()];
@@ -310,10 +304,7 @@ class Multiselect extends Field
             $model = $resourceClass::$model;
             $models = $async && isset($value) ? collect([$model::find($value)]) : $model::all();
 
-            $options = $models->mapInto($this->resourceClass)->mapWithKeys(function ($associatedResource) {
-                return [$associatedResource->getKey() => $associatedResource->title()];
-            });
-            $this->options($options);
+            $this->setOptionsFromModels($models);
 
             return $value;
         });

--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -259,9 +259,8 @@ class Multiselect extends Field
 
             $models = $async ? $value : $resourceClass::$model::all();
 
-            $options = [];
-            $models->each(function ($model) use (&$options, $resourceClass) {
-                $options[$model[$model->getKeyName()]] = $model[$resourceClass::$title];
+            $options = $models->mapInto($this->resourceClass)->mapWithKeys(function ($associatedResource) {
+                return [$associatedResource->getKey() => $associatedResource->title()];
             });
             $this->options($options);
 
@@ -308,16 +307,12 @@ class Multiselect extends Field
             $value = $value->{$primaryKey} ?? null;
             if ($async) $this->asyncResource($resourceClass);
 
-            $options = [];
-            if ($async && isset($value)) {
-                $model = $resourceClass::$model::find($value);
-                if (isset($model)) $options[$model[$primaryKey]] = $model[$resourceClass::$title];
-            } else {
-                $models = $resourceClass::$model::all();
-                $models->each(function ($model) use (&$options, $resourceClass) {
-                    $options[$model[$model->getKeyName()]] = $model[$resourceClass::$title];
-                });
-            }
+            $model = $resourceClass::$model;
+            $models = $async && isset($value) ? collect([$model::find($value)]) : $model::all();
+
+            $options = $models->mapInto($this->resourceClass)->mapWithKeys(function ($associatedResource) {
+                return [$associatedResource->getKey() => $associatedResource->title()];
+            });
             $this->options($options);
 
             return $value;


### PR DESCRIPTION
I needed to use the associated resources title method instead of the static property so I refactored the resolveUsing functions. I included the three commits in the PR so that you might understand my thought process a little better, but let me know if you have any questions or issues.