### PR TITLE
Inverse of nullable not storing empty array([])

### DIFF
--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -113,7 +113,8 @@ class Multiselect extends Field
         if ($singleSelect) {
             $model->{$attribute} = $value;
         } else {
-            $model->{$attribute} = $this->saveAsJSON || is_null($value) ? $value : json_encode($value);
+            $value = is_null($value) ? ($this->nullable ? $value : $value = []) : $value;
+            $model->{$attribute} = ($this->saveAsJSON || is_null($value)) ? $value : json_encode($value);
         }
     }
 


### PR DESCRIPTION
In the documentation, it states that `If the field is nullable an empty select will result in null else an empty array ([]) is stored`  but this is nor working as expected. Where nullable is not set it is still trying to store null which results in NULL constraint error. I am submitting a fix for this.