### PR TITLE
Fix problem when used in Flexible Field

### DIFF
--- a/src/Multiselect.php
+++ b/src/Multiselect.php
@@ -119,7 +119,7 @@ class Multiselect extends Field implements RelatableField
 
     private function shouldSaveAsJson($model, $attribute)
     {
-        if (method_exists($model, 'getCasts')) {
+        if (!is_array($model) && method_exists($model, 'getCasts')) {
             $casts = $model->getCasts();
             $isCastedToArray = ($casts[$attribute] ?? null) === 'array';
             return $this->saveAsJSON || $isCastedToArray;


### PR DESCRIPTION
In order to ensure compatibility within a Flexible field that returns an array,
I had to add a type check